### PR TITLE
Add support for japanese vertical

### DIFF
--- a/TesseractOCR/Enums/Language.cs
+++ b/TesseractOCR/Enums/Language.cs
@@ -383,6 +383,12 @@ namespace TesseractOCR.Enums
         /// </summary>
         [String("jpn")] 
         Japanese,
+        
+        /// <summary>
+        ///     Japanese (vertical)
+        /// </summary>
+        [String("jpn_vert")] 
+        JapaneseVertical,
 
         /// <summary>
         ///     Kannada


### PR DESCRIPTION
Hello,
I noticed the support for Japanese Vertical was missing, when it's available and working correctly in the tesseract data so I added it!