### PR TITLE
Suppprt access to ProcessPages - Version 5.3.6-preview-6

### DIFF
--- a/TesseractOCR.Tests/ResultRendererTests.cs
+++ b/TesseractOCR.Tests/ResultRendererTests.cs
@@ -99,6 +99,40 @@ namespace Tesseract.Tests
             Assert.IsTrue(File.Exists(expectedOutputFilename),
                 $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but none was found.");
         }
+        
+        [TestMethod]
+        public void CanRenderProcessPagesFromFileToPdfFile()
+        {
+            var resultPath = TestResultRunFile(@"Results\PDF\multi-page-from-file");
+            using (var renderer = Result.CreatePdfRenderer(resultPath, DataPath, false))
+            {
+                var examplePixPath = TestFilePath("processing/multi-page.tif");
+                renderer.ProcessPages(examplePixPath, _engine);
+            }
+
+            var expectedOutputFilename = Path.ChangeExtension(resultPath, "pdf");
+
+            Assert.IsTrue(File.Exists(expectedOutputFilename),
+                $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but none was found.");
+        }
+
+        [TestMethod]
+        public void CanRenderProcessPagesFromBytesToPdfFile()
+        {
+            var resultPath = TestResultRunFile(@"Results\PDF\multi-page-from-bytes");
+            using (var renderer = Result.CreatePdfRenderer(resultPath, DataPath, false))
+            {
+                var bytes = File.ReadAllBytes(TestFilePath("processing/multi-page.tif"));
+                renderer.ProcessPages(bytes, _engine);
+            }
+
+            var expectedOutputFilename = Path.ChangeExtension(resultPath, "pdf");
+
+            Assert.IsTrue(File.Exists(expectedOutputFilename),
+                $"Expected a PDF file \"{expectedOutputFilename}\" to have been created; but none was found.");
+            
+            // todo: extract text from pdf and verify content
+        }
 
         [TestMethod]
         public void CanRenderMultiplePageDocumentToPdfFile1()

--- a/TesseractOCR/Renderers/AggregateResult.cs
+++ b/TesseractOCR/Renderers/AggregateResult.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 using System.Linq;
 using TesseractOCR.Helpers;
 using TesseractOCR.Internal;
-using TesseractOCR.Loggers;
 
 namespace TesseractOCR.Renderers
 {
@@ -86,6 +85,27 @@ namespace TesseractOCR.Renderers
 
             return ResultRenderers.All(m => m.AddPage(page));
         }
+
+        /// <inheritdoc />
+        public bool ProcessPages(byte[] data, Engine engine)
+        {
+            Guard.RequireNotNull("data", data);
+            Guard.RequireNotNull("engine", engine);
+            VerifyNotDisposed();
+
+            return ResultRenderers.All(m => m.ProcessPages(data, engine));
+        }
+
+        /// <inheritdoc />
+        public bool ProcessPages(string imgFilePath, Engine engine)
+        {
+            Guard.RequireNotNull("imgFilePath", imgFilePath);
+            Guard.RequireNotNull("engine", engine);
+            VerifyNotDisposed();
+
+            return ResultRenderers.All(m => m.ProcessPages(imgFilePath, engine));
+        }
+
         #endregion
 
         #region BeginDocument

--- a/TesseractOCR/Renderers/IResult.cs
+++ b/TesseractOCR/Renderers/IResult.cs
@@ -40,6 +40,33 @@ namespace TesseractOCR.Renderers
         bool AddPage(Page page);
 
         /// <summary>
+        /// Uses internal file processing. (which is must faster than adding single pages)
+        /// Should behave as if the cmd line was called. Thus will deal with different file formats out of the box
+        /// 
+        /// Data needs to be persisted to disk as temp file before passed down.
+        /// Temp files will be deleted afterwards
+        /// </summary>
+        /// <param name="data">
+        /// The raw bytes of the image to add. tiff, multipage tiff, jpg
+        /// and all other types the cmd line call of tesseract would support
+        /// </param>
+        /// <param name="engine">The engine to be used with the result</param>
+        /// <returns></returns>
+        bool ProcessPages(byte[] data, Engine engine);
+        
+        /// <summary>
+        /// Uses internal file processing. (which is must faster than adding single pages)
+        /// Should behave as if the cmd line was called. Thus will deal with different file formats out of the box
+        /// 
+        /// Data needs to be persisted to disk as temp file before passed down.
+        /// Temp files will be deleted afterwards
+        /// </summary>
+        /// <param name="imgFilePath">The path to the image file to add. tiff, multipage tiff, jpg, etc.</param>
+        /// <param name="engine">The engine to be used for processing</param>
+        /// <returns></returns>
+        bool ProcessPages(string imgFilePath, Engine engine);
+
+        /// <summary>
         ///     Gets the current page number; returning -1 if no page has yet been added otherwise the number
         ///     of the last added page (starting from 0).
         /// </summary>

--- a/TesseractOCR/Renderers/Result.cs
+++ b/TesseractOCR/Renderers/Result.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using TesseractOCR.Enums;
 using TesseractOCR.Internal;
@@ -81,6 +82,29 @@ namespace TesseractOCR.Renderers
             page.Recognize();
 
             return TessApi.Native.ResultRendererAddImage(Handle, page.Engine.Handle) != 0;
+        }
+
+
+        /// <inheritdoc />
+        public bool ProcessPages(byte[] data, Engine engine)
+        {
+            var tmpFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(tmpFile, data);
+                return ProcessPages(tmpFile, engine);
+            }
+            finally
+            {
+                File.Delete(tmpFile);
+            }
+        }
+        
+        /// <inheritdoc />
+        public bool ProcessPages(string imgFilePath, Engine engine)
+        {
+            // config and timeout are not set either when tesseract is called from cmd line
+            return TessApi.Native.BaseApiProcessPages(engine.Handle, imgFilePath, null, 0, _handle) != 0;
         }
         #endregion
 

--- a/TesseractOCR/TesseractOCR.csproj
+++ b/TesseractOCR/TesseractOCR.csproj
@@ -21,7 +21,7 @@ which support the legacy engine, for example those from the tessdata repository.
 		<FileVersion>5.3.6.0</FileVersion>
 		<AssemblyVersion>5.3.6.0</AssemblyVersion>
 		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-		<Version>5.3.6-preview-4</Version>
+		<Version>5.3.6-preview-6</Version>
 		<PackageIcon>ocr.png</PackageIcon>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>


### PR DESCRIPTION
For a 2 page Din A 4 multipage tiff it takes only 2,x seconds rather than 26 seconds when AddPage is called. Rather than processing each page one

Didn't investigate how this delay exactly happens. There's also another difference, when I add the tiff page by page the resulting pdf is about 4 times bigger than expected.
